### PR TITLE
Fix logout redirect while accessing attachment files and make sure th…

### DIFF
--- a/src/Controller/AttachmentsController.php
+++ b/src/Controller/AttachmentsController.php
@@ -27,6 +27,8 @@ class AttachmentsController extends AppController
         if (isset($this->Csrf) && in_array($event->subject()->request->params['action'], ['upload'])) {
             $this->eventManager()->off($this->Csrf);
         }
+
+        parent::beforeFilter($event);
     }
 
     /**


### PR DESCRIPTION
Added the parent call to make sure the plugin can access configured public actions. Reason was that I got redirected and logged out when accessing an attachments URL because authorization failed.